### PR TITLE
dag package documentation

### DIFF
--- a/pkg/dag/node.stringer.go
+++ b/pkg/dag/node.stringer.go
@@ -4,6 +4,18 @@ package dag
 
 import "strconv"
 
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[TypeMiddle-0]
+	_ = x[TypeBeginning-1]
+	_ = x[TypeEnd-2]
+	_ = x[TypeMiddleBeginning-3]
+	_ = x[TypeMiddleEnd-4]
+	_ = x[TypeHidden-5]
+}
+
 const _Type_name = "TypeMiddleTypeBeginningTypeEndTypeMiddleBeginningTypeMiddleEndTypeHidden"
 
 var _Type_index = [...]uint8{0, 10, 23, 30, 49, 62, 72}
@@ -13,6 +25,15 @@ func (i Type) String() string {
 		return "Type(" + strconv.FormatInt(int64(i), 10) + ")"
 	}
 	return _Type_name[_Type_index[i]:_Type_index[i+1]]
+}
+func _() {
+	// An "invalid array index" compiler error signifies that the constant values have changed.
+	// Re-run the stringer command to generate them again.
+	var x [1]struct{}
+	_ = x[statusNotSeen-0]
+	_ = x[statusVisited-1]
+	_ = x[statusDone-2]
+	_ = x[statusFailed-3]
 }
 
 const _status_name = "statusNotSeenstatusVisitedstatusDonestatusFailed"

--- a/pkg/dag/walker.go
+++ b/pkg/dag/walker.go
@@ -5,11 +5,14 @@ import (
 	"io"
 )
 
+// Walker allows to travers a graph.
 type Walker struct {
 	stack
 	previous *Node
 }
 
+// NewWalker instantiate a new Walker object.
+// It will return an error if the given node is not a valid root node.
 func NewWalker(root *Node) (*Walker, error) {
 	if root.kind != TypeBeginning {
 		return nil, errors.New("rosie: dag: start node expected")
@@ -21,8 +24,13 @@ func NewWalker(root *Node) (*Walker, error) {
 	return w, nil
 }
 
+
+// ErrBrokenGraph can be returned by Walk if given graph is not traversable.
 var ErrBrokenGraph = errors.New("rosie: dag: broken graph")
 
+// Walk traverse the graph.
+// It returns nodes in the order they should be processed.
+// It might visit a single node multiple times.
 func (w *Walker) Walk() (*Node, error) {
 	var memory stack
 	defer func() {


### PR DESCRIPTION
**What this PR does / why we need it**:
It adds missing documentation of `pkg/dag` package and let the package pass `golint ./pkg/dag` test. 

**If applicable**:
- [x] this PR contains documentation